### PR TITLE
setup-fmdeps.sh: Avoid trashing switch set via `OPAMSWITCH` (with `--set-switch`), and improve user instructions

### DIFF
--- a/setup-fmdeps.sh
+++ b/setup-fmdeps.sh
@@ -199,23 +199,6 @@ function version_to_int() {
   echo "${res}"
 }
 
-CUR_VER=$(pkg-config --modversion swipl)
-PL_CUR_VER=$(version_to_int ${CUR_VER})
-
-MIN_VER="9.0.0"
-MAX_VER="9.3.8"
-
-PL_MIN_VER=$(version_to_int ${MIN_VER})
-PL_MAX_VER=$(version_to_int ${MAX_VER})
-
-if [[ $PL_CUR_VER -lt $PL_MIN_VER || $PL_CUR_VER -gt $PL_MAX_VER ]]; then
-  echo -e "\033[0;31mError: SWI-prolog version ${CUR_VER} is not supported."
-  echo -e "You need a version between ${MIN_VER} and ${MAX_VER}.\033[0m"
-  errors=1
-else
-  echo "Using SWI-Prolog version ${CUR_VER}."
-fi
-
 # Check LLVM version.
 CLANG_MIN_MAJOR_VER="18"
 CLANG_MAX_MAJOR_VER="20"

--- a/setup-fmdeps.sh
+++ b/setup-fmdeps.sh
@@ -167,10 +167,9 @@ else
   # This will be ${OPAM_SWITCH_NAME} unless the user set ${OPAMSWITCH}
   old_switch="$(opam switch show)"
 
-  # Clear any user-chosen OPAMSWITCH, so that we use the new switch instead in this script
-  unset OPAMSWITCH
-  # Avoid --set-switch here, it would hide misconfigurations from the $(opam switch show) test
-  eval $(opam env)
+  # Switch locally to newly created switch, and overwrite OPAMSWITCH
+  eval $(opam env --switch="${OPAM_SWITCH_NAME}" --set-switch)
+
   opam update
   # We skip this step, and assume fm-ci's opam file is up-to-date.
   # dune build ${opam_file}

--- a/setup-fmdeps.sh
+++ b/setup-fmdeps.sh
@@ -147,6 +147,7 @@ fi
 
 OPAM_SWITCH_NAME="br-${FMDEPS_VERSION}"
 opam_file=${FMDEPS_DIR}/fm-ci/fm-deps/br-fm-deps.opam
+old_switch="$(opam switch show)"
 if opam switch list --short | grep "^${OPAM_SWITCH_NAME}$" > /dev/null; then
   echo -e "\033[0;36mThe opam switch ${OPAM_SWITCH_NAME} already exists, we assume dependencies have been installed. In case of trouble, try rerunning:\033[0m"
   echo -e "\topam install ${opam_file}"
@@ -163,6 +164,9 @@ else
   # This makes the new switch the global default
   opam switch create --empty --repositories="${OPAM_SELECTED_REPOS}" \
     "${OPAM_SWITCH_NAME}"
+  # This will be ${OPAM_SWITCH_NAME} unless the user set ${OPAMSWITCH}
+  old_switch="$(opam switch show)"
+
   # Clear any user-chosen OPAMSWITCH, so that we use the new switch instead in this script
   unset OPAMSWITCH
   # Avoid --set-switch here, it would hide misconfigurations from the $(opam switch show) test
@@ -228,7 +232,7 @@ fi
 # Remind to configure opam.
 
 echo "<<< Caveats >>>"
-if [[ ! `opam switch show` = ${OPAM_SWITCH_NAME} ]]; then
+if [[ ! ${old_switch} = ${OPAM_SWITCH_NAME} ]]; then
   echo
   echo -e "\033[0;36mCurrent switch is not ${OPAM_SWITCH_NAME}, you need to run the following in each shell:\033[0m"
   echo -e \

--- a/setup-fmdeps.sh
+++ b/setup-fmdeps.sh
@@ -160,10 +160,13 @@ else
 
   # Creating the new switch.
   echo "Creating opam switch ${OPAM_SWITCH_NAME}."
+  # This makes the new switch the global default
   opam switch create --empty --repositories="${OPAM_SELECTED_REPOS}" \
     "${OPAM_SWITCH_NAME}"
+  # Clear any user-chosen OPAMSWITCH, so that we use the new switch instead in this script
+  unset OPAMSWITCH
   # Avoid --set-switch here, it would hide misconfigurations from the $(opam switch show) test
-  eval $(opam env --switch="${OPAM_SWITCH_NAME}")
+  eval $(opam env)
   opam update
   # We skip this step, and assume fm-ci's opam file is up-to-date.
   # dune build ${opam_file}


### PR DESCRIPTION
* Supersedes https://github.com/bluerock-io/fm-workspace/pull/7
* Fixes FM-4672.

Co-authored-by: Paolo G. Giarrusso <paolo@bluerock.io>

Co-authored-by: David Swasey <pswasey@riversideresearch.org>